### PR TITLE
handle bignumber internally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-perf",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "",
   "scripts": {
     "lint": "standard",

--- a/src/PerformanceManager.js
+++ b/src/PerformanceManager.js
@@ -12,9 +12,12 @@ class PerformanceManager extends EventEmitter {
     allocation
   }) {
     super()
+    if (!allocation) {
+      throw new Error('Capital Allocation is mandatory')
+    }
 
     this.maxPositionSize = maxPositionSize && new BigNumber(maxPositionSize)
-    this.allocation = allocation && new BigNumber(allocation)
+    this.allocation = new BigNumber(allocation)
     this.availableFunds = new BigNumber(allocation)
     this.priceFeed = priceFeed
 

--- a/src/PerformanceManager.js
+++ b/src/PerformanceManager.js
@@ -4,8 +4,8 @@ const BigNumber = require('bignumber.js')
 class PerformanceManager extends EventEmitter {
   /**
    * @param priceFeed
-   * @param {BigNumber|undefined} maxPositionSize
-   * @param {BigNumber} allocation
+   * @param maxPositionSize
+   * @param allocation
    */
   constructor (priceFeed, {
     maxPositionSize,
@@ -13,8 +13,8 @@ class PerformanceManager extends EventEmitter {
   }) {
     super()
 
-    this.maxPositionSize = maxPositionSize
-    this.allocation = allocation
+    this.maxPositionSize = maxPositionSize && new BigNumber(maxPositionSize)
+    this.allocation = allocation && new BigNumber(allocation)
     this.availableFunds = new BigNumber(allocation)
     this.priceFeed = priceFeed
 
@@ -27,11 +27,14 @@ class PerformanceManager extends EventEmitter {
   }
 
   /**
-   * @param {BigNumber} amount
-   * @param {BigNumber} price
+   * @param amount
+   * @param price
    * @returns {Error|null}
    */
   canOpenOrder (amount, price) {
+    amount = new BigNumber(amount)
+    price = new BigNumber(price)
+
     if (amount.isZero()) {
       throw new Error('amount can not be zero')
     }
@@ -81,7 +84,10 @@ class PerformanceManager extends EventEmitter {
     )
   }
 
-  addOrder ({ amount, price }) {
+  addOrder (amount, price) {
+    amount = new BigNumber(amount)
+    price = new BigNumber(price)
+
     const total = amount.multipliedBy(price)
 
     if (amount.isPositive()) {

--- a/src/PriceFeed.js
+++ b/src/PriceFeed.js
@@ -1,12 +1,14 @@
 const EventEmitter = require('events')
+const BigNumber = require('bignumber.js')
 
 class PriceFeed extends EventEmitter {
   constructor (price = null) {
     super()
-    this.price = price
+    this.price = price && new BigNumber(price)
   }
 
   update (price) {
+    price = new BigNumber(price)
     this.price = price
     this.emit('update', price)
   }

--- a/test/AbsoluteStopLossWatcher.js
+++ b/test/AbsoluteStopLossWatcher.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 
 const { stub, assert } = require('sinon')
-const BigNumber = require('bignumber.js')
 
 const PerformanceManager = require('../src/PerformanceManager')
 const AbsoluteStopLossWatcher = require('../src/AbsoluteStopLossWatcher')
@@ -10,21 +9,18 @@ const PriceFeed = require('../src/PriceFeed')
 
 describe('AbsoluteStopLossWatcher', () => {
   it('should emit stop event', (done) => {
-    const priceFeed = new PriceFeed(new BigNumber(1000))
+    const priceFeed = new PriceFeed(1000)
     const pos = new PerformanceManager(priceFeed, {
-      maxPositionSize: new BigNumber(10),
-      allocation: new BigNumber(1000)
+      maxPositionSize: 10,
+      allocation: 1000
     })
-    const watcher = new AbsoluteStopLossWatcher(pos, new BigNumber(100))
+    const watcher = new AbsoluteStopLossWatcher(pos, 100)
     watcher.start()
     watcher.abortStrategy = stub()
 
-    pos.addOrder({
-      amount: new BigNumber(1),
-      price: new BigNumber(1000)
-    })
+    pos.addOrder(1, 1000)
 
-    priceFeed.update(new BigNumber(800))
+    priceFeed.update(800)
 
     setImmediate(() => {
       assert.called(watcher.abortStrategy)

--- a/test/DrawdownWatcher.js
+++ b/test/DrawdownWatcher.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 
 const { stub, assert } = require('sinon')
-const BigNumber = require('bignumber.js')
 
 const PerformanceManager = require('../src/PerformanceManager')
 const DrawdownWatcher = require('../src/DrawdownWatcher')

--- a/test/DrawdownWatcher.js
+++ b/test/DrawdownWatcher.js
@@ -10,22 +10,19 @@ const PriceFeed = require('../src/PriceFeed')
 
 describe('DrawdownWatcher', () => {
   it('should emit stop event', (done) => {
-    const priceFeed = new PriceFeed(new BigNumber(1000))
+    const priceFeed = new PriceFeed(1000)
     const pos = new PerformanceManager(priceFeed, {
-      maxPositionSize: new BigNumber(10),
-      allocation: new BigNumber(1000)
+      maxPositionSize: 10,
+      allocation: 1000
     })
-    const watcher = new DrawdownWatcher(pos, new BigNumber(0.2))
+    const watcher = new DrawdownWatcher(pos, 0.2)
     watcher.start()
     watcher.abortStrategy = stub()
 
-    pos.addOrder({
-      amount: new BigNumber(1),
-      price: new BigNumber(1000)
-    })
+    pos.addOrder(1, 1000)
 
-    priceFeed.update(new BigNumber(1500))
-    priceFeed.update(new BigNumber(800))
+    priceFeed.update(1500)
+    priceFeed.update(800)
 
     setImmediate(() => {
       assert.called(watcher.abortStrategy)

--- a/test/PercentageStopLossWatcher.js
+++ b/test/PercentageStopLossWatcher.js
@@ -2,7 +2,6 @@
 /* eslint-env mocha */
 
 const { stub, assert } = require('sinon')
-const BigNumber = require('bignumber.js')
 
 const PerformanceManager = require('../src/PerformanceManager')
 const PercentageStopLossWatcher = require('../src/PercentageStopLossWatcher')

--- a/test/PercentageStopLossWatcher.js
+++ b/test/PercentageStopLossWatcher.js
@@ -10,21 +10,18 @@ const PriceFeed = require('../src/PriceFeed')
 
 describe('PercentageStopLossWatcher', () => {
   it('should emit stop event', (done) => {
-    const priceFeed = new PriceFeed(new BigNumber(1000))
+    const priceFeed = new PriceFeed(1000)
     const pos = new PerformanceManager(priceFeed, {
-      maxPositionSize: new BigNumber(10),
-      allocation: new BigNumber(1000)
+      maxPositionSize: 10,
+      allocation: 1000
     })
-    const watcher = new PercentageStopLossWatcher(pos, new BigNumber(0.2))
+    const watcher = new PercentageStopLossWatcher(pos, 0.2)
     watcher.start()
     watcher.abortStrategy = stub()
 
-    pos.addOrder({
-      amount: new BigNumber(1),
-      price: new BigNumber(1000)
-    })
+    pos.addOrder(1, 1000)
 
-    priceFeed.update(new BigNumber(800))
+    priceFeed.update(800)
 
     setImmediate(() => {
       assert.called(watcher.abortStrategy)

--- a/test/PerformanceManager.js
+++ b/test/PerformanceManager.js
@@ -9,11 +9,11 @@ const PerformanceManager = require('../src/PerformanceManager')
 const PriceFeed = require('../src/PriceFeed')
 
 describe('PerformanceManager', () => {
-  const priceFeed = new PriceFeed(new BigNumber(35000))
+  const priceFeed = new PriceFeed(35000)
 
   const constraints = {
-    maxPositionSize: new BigNumber(1),
-    allocation: new BigNumber(13000)
+    maxPositionSize: 1,
+    allocation: 13000
   }
 
   describe('position management', () => {
@@ -32,28 +32,16 @@ describe('PerformanceManager', () => {
     })
 
     it('add orders', (done) => {
-      pos.addOrder({
-        amount: new BigNumber('0.1'),
-        price: new BigNumber('35000')
-      })
+      pos.addOrder('0.1', '35000')
 
-      pos.addOrder({
-        amount: new BigNumber('0.1'),
-        price: new BigNumber('37089.17')
-      })
-      priceFeed.update(new BigNumber('37089.17'))
+      pos.addOrder('0.1', '37089.17')
+      priceFeed.update('37089.17')
 
-      pos.addOrder({
-        amount: new BigNumber('0.1'),
-        price: new BigNumber('40229.09')
-      })
-      priceFeed.update(new BigNumber('40229.09'))
+      pos.addOrder('0.1', '40229.09')
+      priceFeed.update('40229.09')
 
-      pos.addOrder({
-        amount: new BigNumber('0.04709128732'),
-        price: new BigNumber('37547.71')
-      })
-      priceFeed.update(new BigNumber('37547.71'))
+      pos.addOrder('0.04709128732', '37547.71')
+      priceFeed.update('37547.71')
 
       setImmediate(() => {
         expect(pos.positionSize().toFixed(2)).to.eq('0.35')
@@ -70,7 +58,7 @@ describe('PerformanceManager', () => {
     })
 
     it('update price', (done) => {
-      priceFeed.update(new BigNumber('34955.37'))
+      priceFeed.update('34955.37')
 
       setImmediate(() => {
         expect(pos.equityCurve().toFixed(2)).to.eq('12132.71')
@@ -82,10 +70,7 @@ describe('PerformanceManager', () => {
     })
 
     it('sell all', () => {
-      pos.addOrder({
-        amount: pos.positionSize().negated(),
-        price: new BigNumber('32177.86')
-      })
+      pos.addOrder(pos.positionSize().negated(), '32177.86')
 
       expect(pos.positionSize().toFixed(2)).to.eq('0.00')
       expect(pos.currentAllocation().toFixed(2)).to.eq('0.00')
@@ -98,10 +83,7 @@ describe('PerformanceManager', () => {
 
     it('try to over-sell', () => {
       try {
-        pos.addOrder({
-          amount: new BigNumber(-1),
-          price: new BigNumber('32177.86')
-        })
+        pos.addOrder(-1, '32177.86')
         assert.fail()
       } catch (e) {
         expect(e.message).to.eq('can not over-sell position')
@@ -112,22 +94,13 @@ describe('PerformanceManager', () => {
   describe('add orders', () => {
     it('partial sell', () => {
       const pos = new PerformanceManager(priceFeed, constraints)
-      const price = new BigNumber(1000)
+      const price = 1000
 
-      pos.addOrder({
-        amount: new BigNumber(0.3),
-        price
-      })
+      pos.addOrder(0.3, price)
 
-      pos.addOrder({
-        amount: new BigNumber(0.7),
-        price
-      })
+      pos.addOrder(0.7, price)
 
-      pos.addOrder({
-        amount: new BigNumber(-0.5),
-        price
-      })
+      pos.addOrder(-0.5, price)
 
       expect(pos.positionSize().toNumber()).to.eq(0.5)
     })
@@ -137,16 +110,16 @@ describe('PerformanceManager', () => {
     const pos = new PerformanceManager(priceFeed, constraints)
 
     it('order is valid', () => {
-      const amount = new BigNumber(0.5)
-      const price = new BigNumber(500)
+      const amount = 0.5
+      const price = 500
       const err = pos.canOpenOrder(amount, price)
 
       expect(err).to.be.null
     })
 
     it('max size exceeded', () => {
-      const amount = new BigNumber(4)
-      const price = new BigNumber(500)
+      const amount = 4
+      const price = 500
       const err = pos.canOpenOrder(amount, price)
 
       expect(err).to.be.instanceOf(Error)
@@ -154,8 +127,8 @@ describe('PerformanceManager', () => {
     })
 
     it('max alloc exceeded', () => {
-      const amount = new BigNumber(0.5)
-      const price = new BigNumber(50000)
+      const amount = 0.5
+      const price = 50000
       const err = pos.canOpenOrder(amount, price)
 
       expect(err).to.be.instanceOf(Error)
@@ -163,8 +136,8 @@ describe('PerformanceManager', () => {
     })
 
     it('total is greater than the available funds', () => {
-      const amount = new BigNumber(0.5)
-      const price = new BigNumber(3000)
+      const amount = 0.5
+      const price = 3000
 
       const pos = new PerformanceManager(priceFeed, constraints)
       pos.availableFunds = new BigNumber(500)
@@ -175,8 +148,8 @@ describe('PerformanceManager', () => {
     })
 
     it('short not allowed', () => {
-      const amount = new BigNumber(-0.5)
-      const price = new BigNumber(50000)
+      const amount = -0.5
+      const price = 50000
       const pos = new PerformanceManager(priceFeed, constraints)
       const err = pos.canOpenOrder(amount, price)
 


### PR DESCRIPTION
Because the performance manager uses the `bignumber.js` lib, this dependency end-up spreading across other libraries, it should accept any type of number and convert it internally.

Breaking change:
This PR also changes the method signature of `addOrder` to use the same signature as `canOpenOrder`.