### PR TITLE
batch price updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-perf",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "",
   "scripts": {
     "lint": "standard",

--- a/src/PriceFeed.js
+++ b/src/PriceFeed.js
@@ -1,19 +1,64 @@
 const EventEmitter = require('events')
 const BigNumber = require('bignumber.js')
 
+// buffer the price updates in time buckets
+const defaultTimeBucketSize = 10 * 1000
+
 class PriceFeed extends EventEmitter {
-  constructor (price = null) {
+  constructor ({ timeBucketSize = defaultTimeBucketSize, initialPrice = null } = {}) {
     super()
-    this.price = price && new BigNumber(price)
+    this.price = initialPrice && new BigNumber(initialPrice)
+    this.timeBucket = null
+    this.timeBucketSize = timeBucketSize
+    this.dataPoints = []
+    this.timeout = null
   }
 
-  update (price) {
+  update (price, mts, force = false) {
     price = new BigNumber(price)
-    this.price = price
-    this.emit('update', price)
+    const timeBucket = Math.floor(mts / this.timeBucketSize)
+
+    if (this.price === null || timeBucket > this.timeBucket || force) {
+      clearTimeout(this.timeout)
+
+      this.price = price
+      this.dataPoints = [price]
+      this.timeBucket = timeBucket
+
+      if (force) {
+        this.emit('update', price)
+      }
+
+      const delay = (timeBucket * this.timeBucketSize) + this.timeBucketSize - mts
+      this.timeout = setTimeout(this._sendAveragePrice.bind(this), delay)
+
+      return
+    }
+
+    if (timeBucket === this.timeBucket) {
+      this.dataPoints.push(price)
+    }
+  }
+
+  _sendAveragePrice () {
+    if (this.dataPoints.length === 0) {
+      return
+    }
+
+    const sum = this.dataPoints.reduce(
+      (acc, val) => acc.plus(val),
+      new BigNumber(0)
+    )
+    const averagePrice = sum.dividedBy(this.dataPoints.length)
+
+    this.price = averagePrice
+    this.emit('update', averagePrice)
   }
 
   close () {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
     this.removeAllListeners()
   }
 }

--- a/test/DrawdownWatcher.js
+++ b/test/DrawdownWatcher.js
@@ -8,20 +8,23 @@ const DrawdownWatcher = require('../src/DrawdownWatcher')
 const PriceFeed = require('../src/PriceFeed')
 
 describe('DrawdownWatcher', () => {
+  const priceFeed = new PriceFeed({ initialPrice: 1000 })
+  const mts = Date.now()
+
+  const pos = new PerformanceManager(priceFeed, {
+    maxPositionSize: 10,
+    allocation: 1000
+  })
+
   it('should emit stop event', (done) => {
-    const priceFeed = new PriceFeed(1000)
-    const pos = new PerformanceManager(priceFeed, {
-      maxPositionSize: 10,
-      allocation: 1000
-    })
     const watcher = new DrawdownWatcher(pos, 0.2)
     watcher.start()
     watcher.abortStrategy = stub()
 
     pos.addOrder(1, 1000)
 
-    priceFeed.update(1500)
-    priceFeed.update(800)
+    priceFeed.update(1500, mts, true)
+    priceFeed.update(800, mts, true)
 
     setImmediate(() => {
       assert.called(watcher.abortStrategy)

--- a/test/PerformanceManager.js
+++ b/test/PerformanceManager.js
@@ -9,8 +9,8 @@ const PerformanceManager = require('../src/PerformanceManager')
 const PriceFeed = require('../src/PriceFeed')
 
 describe('PerformanceManager', () => {
-  const priceFeed = new PriceFeed(35000)
-
+  const priceFeed = new PriceFeed({ initialPrice: 35000 })
+  const mts = Date.now()
   const constraints = {
     maxPositionSize: 1,
     allocation: 13000
@@ -35,13 +35,13 @@ describe('PerformanceManager', () => {
       pos.addOrder('0.1', '35000')
 
       pos.addOrder('0.1', '37089.17')
-      priceFeed.update('37089.17')
+      priceFeed.update('37089.17', mts, true)
 
       pos.addOrder('0.1', '40229.09')
-      priceFeed.update('40229.09')
+      priceFeed.update('40229.09', mts, true)
 
       pos.addOrder('0.04709128732', '37547.71')
-      priceFeed.update('37547.71')
+      priceFeed.update('37547.71', mts, true)
 
       setImmediate(() => {
         expect(pos.positionSize().toFixed(2)).to.eq('0.35')
@@ -58,7 +58,7 @@ describe('PerformanceManager', () => {
     })
 
     it('update price', (done) => {
-      priceFeed.update('34955.37')
+      priceFeed.update('34955.37', mts, true)
 
       setImmediate(() => {
         expect(pos.equityCurve().toFixed(2)).to.eq('12132.71')

--- a/test/PriceFeed.js
+++ b/test/PriceFeed.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-env mocha */
+
+const { stub, assert } = require('sinon')
+const { expect } = require('chai')
+
+const PriceFeed = require('../src/PriceFeed')
+const BigNumber = require('bignumber.js')
+
+describe('PriceFeed', () => {
+  const timeBucketSize = 500
+
+  it('first update', (done) => {
+    const price = 32000
+    const mts = new Date(2022, 7, 8, 10, 0, 0, 0)
+
+    const feed = new PriceFeed({ timeBucketSize })
+
+    feed.once('update', (updatedPrice) => {
+      expect(updatedPrice.toNumber()).to.eq(price)
+      feed.close()
+      done()
+    })
+
+    feed.update(price, mts.getTime())
+    expect(feed.price.toNumber()).to.eq(price)
+  })
+
+  it('average the price of the current time bucket', (done) => {
+    const price = 32000
+    const mts = new Date(2022, 7, 8, 10, 0, 0, 0).getTime()
+
+    const feed = new PriceFeed({ timeBucketSize })
+
+    feed.once('update', (updatedPrice) => {
+      expect(updatedPrice.toNumber()).to.eq(31952.5)
+      feed.close()
+      done()
+    })
+
+    feed.update(price, mts + 50)
+    feed.update(price + 390, mts + 80)
+    feed.update(price - 760, mts + 120)
+    feed.update(price + 180, mts + 190)
+  })
+
+  it('received a most up-to-date price', (done) => {
+    const price = 32000
+    const mts = new Date(2022, 7, 8, 10, 0, 0, 0).getTime()
+
+    const feed = new PriceFeed({ timeBucketSize })
+
+    feed.once('update', (updatedPrice) => {
+      expect(updatedPrice.toNumber()).to.eq(33000)
+      feed.close()
+      done()
+    })
+
+    feed.update(price, mts)
+    feed.update(price + 1000, mts + (2 * timeBucketSize))
+  })
+
+  it('outdated mts update', (done) => {
+    const price = 32000
+    const mts = new Date(2022, 7, 8, 10, 0, 0, 0).getTime()
+
+    const feed = new PriceFeed({ timeBucketSize })
+
+    feed.once('update', (updatedPrice) => {
+      expect(updatedPrice.toNumber()).to.eq(price)
+      feed.close()
+      done()
+    })
+
+    feed.update(price, mts)
+    feed.update(price + 390, mts - (3 * timeBucketSize))
+  })
+})

--- a/test/PriceFeed.js
+++ b/test/PriceFeed.js
@@ -1,11 +1,9 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 
-const { stub, assert } = require('sinon')
 const { expect } = require('chai')
 
 const PriceFeed = require('../src/PriceFeed')
-const BigNumber = require('bignumber.js')
 
 describe('PriceFeed', () => {
   const timeBucketSize = 500


### PR DESCRIPTION
Price feed should batch the updates into an average price every 10 seconds to back-pressure the updates coming from trade data.