### PR TITLE
use peak for drawdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-perf",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "scripts": {
     "lint": "standard",

--- a/src/PerformanceManager.js
+++ b/src/PerformanceManager.js
@@ -22,7 +22,6 @@ class PerformanceManager extends EventEmitter {
     this.priceFeed = priceFeed
 
     this.peak = new BigNumber(allocation)
-    this.prevPeak = new BigNumber(0)
     this.trough = new BigNumber(allocation)
     this.openOrders = []
 
@@ -150,10 +149,10 @@ class PerformanceManager extends EventEmitter {
    */
   drawdown () {
     const equityCurve = this.equityCurve()
-    if (equityCurve.isGreaterThanOrEqualTo(this.prevPeak) || this.prevPeak.isZero()) {
+    if (equityCurve.isGreaterThanOrEqualTo(this.peak) || this.peak.isZero()) {
       return new BigNumber(0)
     }
-    return this.prevPeak.minus(equityCurve).dividedBy(this.prevPeak)
+    return this.peak.minus(equityCurve).dividedBy(this.peak)
   }
 
   /**
@@ -171,7 +170,6 @@ class PerformanceManager extends EventEmitter {
   updatePeak () {
     const equityCurve = this.equityCurve()
     if (equityCurve.isGreaterThan(this.peak)) {
-      this.prevPeak = this.peak
       this.peak = equityCurve
     }
   }


### PR DESCRIPTION
To calculate the drawdown we need to use the most recent value for the peak of the equity curve.